### PR TITLE
Add missing SOURCELINK_SUFFIX

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -183,7 +183,8 @@ Like looking at code? Help us! https://github.com/certbot/certbot
             VERSION:'{{ release|e }}',
             COLLAPSE_INDEX:false,
             FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
-            HAS_SOURCE:  {{ has_source|lower }}
+            HAS_SOURCE:  {{ has_source|lower }},
+            SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
         };
     </script>
     {%- for scriptfile in script_files %}

--- a/sphinx_rtd_theme/layout_old.html
+++ b/sphinx_rtd_theme/layout_old.html
@@ -91,7 +91,8 @@
         VERSION:     '{{ release|e }}',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '{{ '' if no_search_suffix else file_suffix }}',
-        HAS_SOURCE:  {{ has_source|lower }}
+        HAS_SOURCE:  {{ has_source|lower }},
+        SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
       };
     </script>
     {%- for scriptfile in script_files %}


### PR DESCRIPTION
Adds DOCUMENTATION_OPTIONS.SOURCELINK_SUFFIX which is expected by the
searchtools.js

Related sphinx commit:
https://github.com/sphinx-doc/sphinx/commit/71dd8bfbf94417ad55b2444e1dbd219db266f335