### PR TITLE
Update docs path

### DIFF
--- a/sphinx_rtd_theme/breadcrumbs.html
+++ b/sphinx_rtd_theme/breadcrumbs.html
@@ -10,7 +10,7 @@
 {% set github_user = "certbot" %}
 {% set github_repo = "certbot" %}
 {% set github_version = "master" %}
-{% set conf_py_path = "/docs/" %}
+{% set conf_py_path = "/certbot/docs/" %}
 
 <div role="navigation" aria-label="breadcrumbs navigation">
   <ul class="wy-breadcrumbs">


### PR DESCRIPTION
In https://github.com/certbot/certbot/pull/7544 we moved the location of Certbot's docs from the root of the Certbot repo to under the `certbot` directory. This PR updates the path here resolving the build failures on the certbot/website repo caused by broken links to the old location of the files. See https://travis-ci.com/certbot/website/builds/138908418#L1286.

I tested this with my fork at https://travis-ci.com/certbot/website/jobs/262405122#L1289 and tests still failed, but they'll be full fixed when both this PR and https://github.com/certbot/website/pull/507 land. https://github.com/certbot/website/pull/507 is blocked on this PR.