### PR TITLE
fix search

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -177,16 +177,8 @@ Like looking at code? Help us! https://github.com/certbot/certbot
 
   {% if not embedded %}
 
-    <script type="text/javascript">
-        var DOCUMENTATION_OPTIONS = {
-            URL_ROOT:'{{ url_root }}',
-            VERSION:'{{ release|e }}',
-            COLLAPSE_INDEX:false,
-            FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
-            HAS_SOURCE:  {{ has_source|lower }},
-            SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
-        };
-    </script>
+    {# EFF edit: documentation_options is backported here to fix compatibility with newer sphinx -#}
+    <script id="documentation_options" data-url_root="{{ url_root }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
     {%- for scriptfile in script_files %}
       <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
     {%- endfor %}

--- a/sphinx_rtd_theme/search.html
+++ b/sphinx_rtd_theme/search.html
@@ -10,6 +10,8 @@
 {%- extends "layout.html" %}
 {% set title = _('Search') %}
 {% set script_files = script_files + ['_static/searchtools.js'] %}
+{# EFF edit: language_data is included here to fix compatibility with sphinx>=3.4.0 -#}
+{% set script_files = script_files + ['_static/language_data.js'] %}
 {% block footer %}
   <script type="text/javascript">
     jQuery(function() { Search.loadIndex("{{ pathto('searchindex.js', 1) }}"); });


### PR DESCRIPTION
This is a proposed fix for https://github.com/certbot/website/issues/711.

The core of the issue seems to be the very old fork of sphinx_rtd_theme that we are maintaining. As we upgrade to newer Sphinx versions, it looks like we are hitting various incompatibilities.

This change backports two JavaScript changes to make search work again:

1. Including `language_data.js` which newer Sphinx stopped including on all pages
2. Including `documentation_options.js` which replaces the inline `DOCUMENTATION_OPTIONS` in newer Sphinx

Alternatively we could look into whether it's possible to ditch this fork of `sphinx_rtd_theme`, but I'm not sure of the original reason for its existence.

Testing this was complicated. I did this by changing the fork URI in `_docs.sh`.  `gulp build` spits out the correct HTML into `_site`, but for some reason, testing the site via Docker (the localhost:4000 server) shows the old code, even after blowing away the containers and rebuilding the image. I'm not sure why.